### PR TITLE
Adding client.contract(id, address)

### DIFF
--- a/lib/coingecko_ruby/client/coins.rb
+++ b/lib/coingecko_ruby/client/coins.rb
@@ -223,6 +223,11 @@ module CoingeckoRuby
       def get_markets(ids:, currency: 'usd', options: {})
         markets(ids, vs_currency: currency, **options)
       end
+
+      def contract(id, address, **options)
+        get "coins/#{id}/contract/#{address}", **options
+      end
+
     end
   end
 end


### PR DESCRIPTION
Adding the ability to look up a by network id (ethereum) and address.

Sample usage
```
coingecko = CoingeckoRuby::Client.new
coingecko_data = coingecko.contract('ethereum', '0xd69f306549e9d96f183b1aeca30b8f4353c2ecc3')
```